### PR TITLE
calendar: add children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2021-11-18
 ### Added
-- Support lacales with date-fns
+- Support locales with date-fns
 - Month name and year format
 - Month missing `styles.month` prop
 

--- a/src/calendar.stories.tsx
+++ b/src/calendar.stories.tsx
@@ -12,11 +12,10 @@ import {
   VStack,
   useDisclosure,
 } from '@chakra-ui/react'
-import { format, addDays, subDays, addMonths } from 'date-fns'
+import { format, addDays, subDays, addMonths, subMonths } from 'date-fns'
 import { CalendarValues, CalendarDate } from './types'
 import { Calendar } from './calendar'
 import ptBR from 'date-fns/locale/pt-BR'
-import { subMonths } from 'date-fns/esm'
 
 export default {
   title: 'Calendar',

--- a/src/calendar.stories.tsx
+++ b/src/calendar.stories.tsx
@@ -9,12 +9,14 @@ import {
   PopoverBody,
   Box,
   Button,
+  VStack,
   useDisclosure,
 } from '@chakra-ui/react'
 import { format, addDays, subDays, addMonths } from 'date-fns'
 import { CalendarValues, CalendarDate } from './types'
 import { Calendar } from './calendar'
 import ptBR from 'date-fns/locale/pt-BR'
+import { subMonths } from 'date-fns/esm'
 
 export default {
   title: 'Calendar',
@@ -241,5 +243,89 @@ export const AllowOutsideDays: ComponentStory<typeof Calendar> = () => {
       value={dates}
       onSelectDate={handleSelectDate}
     />
+  )
+}
+
+export const PresetDates: ComponentStory<typeof Calendar> = () => {
+  const [dates, setDates] = useState<CalendarValues>({
+    start: undefined,
+    end: undefined,
+  })
+
+  const handleSelectDate = (dates: CalendarValues) => {
+    setDates(dates)
+  }
+
+  const date = new Date()
+
+  const handleSelectPastPresetDates = (amount: number, isMonth?: boolean) => {
+    setDates({
+      start: isMonth ? subMonths(date, amount) : subDays(date, amount),
+      end: new Date(),
+    })
+  }
+
+  const handleSelectFuturePresetDates = (amount: number, isMonth?: boolean) => {
+    setDates({
+      start: new Date(),
+      end: isMonth ? addMonths(date, amount) : addDays(date, amount),
+    })
+  }
+
+  return (
+    <Calendar value={dates} onSelectDate={handleSelectDate}>
+      <VStack
+        spacing={4}
+        py={6}
+        p={4}
+        h="100%"
+        alignItems="stretch"
+        bgColor="gray.50"
+        borderEndRadius="md"
+      >
+        <Button
+          onClick={() => handleSelectPastPresetDates(7)}
+          colorScheme="teal"
+          size="xs"
+        >
+          last 7 days
+        </Button>
+        <Button
+          onClick={() => handleSelectPastPresetDates(14)}
+          colorScheme="teal"
+          size="xs"
+        >
+          last 14 days
+        </Button>
+        <Button
+          onClick={() => handleSelectPastPresetDates(1, true)}
+          colorScheme="teal"
+          size="xs"
+        >
+          last month
+        </Button>
+        <Button
+          onClick={() => handleSelectFuturePresetDates(7)}
+          colorScheme="pink"
+          size="xs"
+        >
+          next 7 days
+        </Button>
+        <Button
+          onClick={() => handleSelectFuturePresetDates(14)}
+          colorScheme="pink"
+          size="xs"
+        >
+          next 14 days
+        </Button>
+        <Button
+          onClick={() => handleSelectFuturePresetDates(1, true)}
+          colorScheme="pink"
+          size="xs"
+        >
+          next month
+        </Button>
+      </VStack>
+    </Calendar>
   )
 }

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Box, Grid, useMultiStyleConfig } from '@chakra-ui/react'
+import { ReactNode, useState } from 'react'
+import { Box, Grid, useMultiStyleConfig, Flex } from '@chakra-ui/react'
 import { isAfter, isBefore, isSameDay, Locale } from 'date-fns'
 import { Target } from './types'
 import type { CalendarDate, CalendarValues, Buttons } from './types'
@@ -22,6 +22,7 @@ export type Calendar = {
   onSelectDate: (value: CalendarDate | CalendarValues) => void
   nextButton?: Buttons
   prevButton?: Buttons
+  children?: ReactNode
 }
 
 export function Calendar({
@@ -39,6 +40,7 @@ export function Calendar({
   onSelectDate,
   nextButton,
   prevButton,
+  children,
 }: Calendar) {
   const {
     startDateDays,
@@ -88,48 +90,54 @@ export function Calendar({
 
   return (
     <Box sx={styles.calendar}>
-      <Controls
-        prevButton={prevButton}
-        nextButton={nextButton}
-        prevMonth={prevMonth}
-        nextMonth={nextMonth}
-      />
-
-      <Grid sx={styles.months}>
-        <Month
-          locale={locale}
-          startSelectedDate={value?.start}
-          endSelectedDate={value?.end}
-          value={value}
-          date={startDate}
-          days={startDateDays}
-          monthYearFormat={monthYearFormat}
-          weekdayFormat={weekdayFormat}
-          onSelectDate={selectDateHandler}
-          disablePastDates={disablePastDates}
-          disableFutureDates={disableFutureDates}
-          disableWeekends={disableWeekends}
-          disableDates={disableDates}
-        />
-
-        {!onlyOneMonth ? (
-          <Month
-            locale={locale}
-            startSelectedDate={value?.start}
-            endSelectedDate={value?.end}
-            value={value}
-            date={endDate}
-            days={endDateDays}
-            monthYearFormat={monthYearFormat}
-            weekdayFormat={weekdayFormat}
-            onSelectDate={selectDateHandler}
-            disablePastDates={disablePastDates}
-            disableFutureDates={disableFutureDates}
-            disableWeekends={disableWeekends}
-            disableDates={disableDates}
+      <Flex>
+        <Box position="relative">
+          <Controls
+            prevButton={prevButton}
+            nextButton={nextButton}
+            prevMonth={prevMonth}
+            nextMonth={nextMonth}
           />
-        ) : null}
-      </Grid>
+
+          <Grid sx={styles.months}>
+            <Month
+              locale={locale}
+              startSelectedDate={value?.start}
+              endSelectedDate={value?.end}
+              value={value}
+              date={startDate}
+              days={startDateDays}
+              monthYearFormat={monthYearFormat}
+              weekdayFormat={weekdayFormat}
+              onSelectDate={selectDateHandler}
+              disablePastDates={disablePastDates}
+              disableFutureDates={disableFutureDates}
+              disableWeekends={disableWeekends}
+              disableDates={disableDates}
+            />
+
+            {!onlyOneMonth ? (
+              <Month
+                locale={locale}
+                startSelectedDate={value?.start}
+                endSelectedDate={value?.end}
+                value={value}
+                date={endDate}
+                days={endDateDays}
+                monthYearFormat={monthYearFormat}
+                weekdayFormat={weekdayFormat}
+                onSelectDate={selectDateHandler}
+                disablePastDates={disablePastDates}
+                disableFutureDates={disableFutureDates}
+                disableWeekends={disableWeekends}
+                disableDates={disableDates}
+              />
+            ) : null}
+          </Grid>
+        </Box>
+
+        {children ? <Box>{children}</Box> : null}
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
Allow adding a children component to `Calendar` makes it easier to create something to complement or create custom function as preset dates example.