### PR TITLE
calendar: add reset dates on unmount component

### DIFF
--- a/src/calendar.stories.tsx
+++ b/src/calendar.stories.tsx
@@ -92,6 +92,7 @@ export const WithInputs: ComponentStory<typeof Calendar> = () => {
         initialFocusRef={startInputRef}
         isOpen={isOpen}
         onClose={onClose}
+        isLazy
       >
         <PopoverTrigger>
           <Flex

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -1,6 +1,6 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { Box, Grid, useMultiStyleConfig, Flex } from '@chakra-ui/react'
-import { isAfter, isBefore, isSameDay, Locale } from 'date-fns'
+import { isAfter, isBefore, isSameDay, isValid, Locale } from 'date-fns'
 import { Target } from './types'
 import type { CalendarDate, CalendarValues, Buttons } from './types'
 import { Month } from './month'
@@ -49,6 +49,7 @@ export function Calendar({
     endDate,
     nextMonth,
     prevMonth,
+    resetDate,
   } = useCalendar({
     allowOutsideDays: allowOutsideDays && singleMonth,
     blockFuture: disableFutureDates,
@@ -56,6 +57,14 @@ export function Calendar({
   })
 
   const [target, setTarget] = useState<Target>(Target.START)
+
+  useEffect(() => {
+    if (isValid(value.start)) {
+      resetDate()
+    }
+    // missing resetDate, adding resetDate causes to calendar
+    // impossible to navigation through months.
+  }, [value.start])
 
   const styles = useMultiStyleConfig('Calendar', {})
 

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import {
   endOfMonth,
   startOfMonth,
@@ -56,6 +56,8 @@ export function useCalendar({
         end: endDateMonthEndOfWeek,
       })
 
+      const resetDate = () => setDate(initialState)
+
       return {
         startDateDays: allowOutsideDays
           ? startDateDays
@@ -65,6 +67,7 @@ export function useCalendar({
           : replaceOutMonthDays(endDateDays, endDate),
         nextMonth,
         prevMonth,
+        resetDate,
       }
     },
     [
@@ -73,6 +76,7 @@ export function useCalendar({
       endDate,
       endDateMonthEndOfWeek,
       endDateMonthStarOftWeek,
+      initialState,
       startDateMonthEndOfWeek,
       startDateMonthStarOftWeek,
     ]


### PR DESCRIPTION
Add reset date on unmount component.

**obs:** needs to pass a `isLazy` prop to `Popover` chakra-ui component to work properly.