### PR TITLE
fix: rollupconfig input to use types/src

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,7 @@ export default [
     ],
   },
   {
-    input: 'dist/esm/types/index.d.ts',
+    input: 'dist/esm/types/src/index.d.ts',
     output: [
       {
         file: 'dist/index.d.ts',


### PR DESCRIPTION
@uselessdev I was missing type declarations in `Calendar`. 
When I tried to build on my fork of your project, I got error that: `dist/esm/types/index.d.ts` was missing.

So changed it in rollup config to `dist/esm/types/src/index.d.ts`

That seems to work and I assume that will fix the types as well.

But I can not test adding the forked version into my dependencies like this: `"@uselessdev/datepicker": "https://github.com/kivi/datepicker#fix-calendar-type-add-weekStartsOn",`

or using the local source:     `"@uselessdev/datepicker": "../datepicker",`



