### PR TITLE
Fix/add locale option

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -74,7 +74,10 @@ export function Calendar({
     }
 
     if (weekDateSelection) {
-      return onSelectDate({ start: startOfWeek(date), end: endOfWeek(date) })
+      return onSelectDate({
+        start: startOfWeek(date, { locale }),
+        end: endOfWeek(date, { locale }),
+      })
     }
 
     if (

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -76,8 +76,8 @@ export function Calendar({
 
     if (weekDateSelection) {
       return onSelectDate({
-        start: startOfWeek(date, { locale }),
-        end: endOfWeek(date, { locale }),
+        start: startOfWeek(date, { locale, weekStartsOn }),
+        end: endOfWeek(date, { locale, weekStartsOn }),
       })
     }
 

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -54,6 +54,7 @@ export function Calendar({
     blockFuture: false,
     start: value?.start || new Date(),
     months,
+    locale,
     weekStartsOn,
   })
 

--- a/src/month-week.tsx
+++ b/src/month-week.tsx
@@ -11,7 +11,7 @@ type Weekdays = {
 }
 
 function weekdays({ weekdayFormat = 'E', locale, weekStartsOn }: Weekdays) {
-  const start = startOfWeek(new Date(), { weekStartsOn })
+  const start = startOfWeek(new Date(), { locale, weekStartsOn })
   return [...Array(7).keys()].map(i =>
     format(addDays(start, i), weekdayFormat, { locale })
   )

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -31,7 +31,7 @@ export function useCalendar({
   blockFuture,
   allowOutsideDays,
   locale,
-  weekStartsOn = 0,
+  weekStartsOn,
 }: UseCalendar) {
   const initialState = blockFuture ? subMonths(start, 1) : start
   const [date, setDate] = React.useState<CalendarDate>(initialState)

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -5,6 +5,7 @@ import {
   endOfMonth,
   endOfWeek,
   isSameMonth,
+  Locale,
   startOfMonth,
   startOfWeek,
   subMonths,
@@ -20,6 +21,7 @@ export type UseCalendar = {
   blockFuture?: boolean
   allowOutsideDays?: boolean
   months?: number
+  locale?: Locale
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
 }
 
@@ -28,6 +30,7 @@ export function useCalendar({
   months = 1,
   blockFuture,
   allowOutsideDays,
+  locale,
   weekStartsOn = 0,
 }: UseCalendar) {
   const initialState = blockFuture ? subMonths(start, 1) : start
@@ -45,8 +48,11 @@ export function useCalendar({
 
         const startDateOfMonth = startOfMonth(month)
         const endDateOfMonth = endOfMonth(month)
-        const startWeek = startOfWeek(startDateOfMonth, { weekStartsOn })
-        const endWeek = endOfWeek(endDateOfMonth, { weekStartsOn })
+        const startWeek = startOfWeek(startDateOfMonth, {
+          locale,
+          weekStartsOn,
+        })
+        const endWeek = endOfWeek(endDateOfMonth, { locale, weekStartsOn })
         const days = eachDayOfInterval({ start: startWeek, end: endWeek })
 
         return {

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import {
-  endOfMonth,
-  startOfMonth,
-  eachDayOfInterval,
   addMonths,
-  startOfWeek,
-  isSameMonth,
-  subMonths,
+  eachDayOfInterval,
+  endOfMonth,
   endOfWeek,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
 } from 'date-fns'
 import type { CalendarDate } from './types'
 


### PR DESCRIPTION
Closes #39 .

## Notes

Good day, @uselessdev. Not until I tried to address #39 did I realize that the interfaces already have the `weekStartsOn` option. This PR adds the `locale` to the date-fn options along with some existing `weekStartsOn` option. I'm not sure if you like this approach though so please feel free to ditch this PR.

Although `date-fns` also supports specifying `locale` and `weekStartsOn` in the options in the same time, I personally prefer keeping only the `locale` option in the interface for simplicity. But this involves a breaking change so let's discuss it first.

## Pros and Cons of Keeping Only the `locale`

### Pros

- Simplicity
- Less cognitive overload
- Align with date-fns

### Cons

- Breaking changes
- Unable to customize if we don't want to pull in a locale object
