### PR TITLE
Remove condition that prevent to select same day

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -81,13 +81,6 @@ export function Calendar({
       })
     }
 
-    if (
-      (value.start && isSameDay(date, value.start)) ||
-      (value.end && isSameDay(date, value.end))
-    ) {
-      return
-    }
-
     if (value.start && isBefore(date, value.start)) {
       return onSelectDate({ ...value, start: date })
     }


### PR DESCRIPTION
Hey guys! :grin: 

Well, im starting to use this datepicker, and i liked very much, but the component does'nt allow me to choose the sameday in the 'start' and the 'end' props (prop value, actually).

So, this PR suggest to remove the condition that prevent to select the same day.

As argument to do this change, is that even AntDesign and MaterialUI allow to select the same day in your range date pickers.

If it is a significative change to the users of the component, maybe a new prop to this new comportament?

Well, thats it!
Thanks!! :grinning: 