### PR TITLE
Allow select the same day in a date range selection

### DIFF
--- a/src/calendar.stories.tsx
+++ b/src/calendar.stories.tsx
@@ -827,13 +827,13 @@ export const WithCustomDay: ComponentStory<typeof Calendar> = () => {
   )
 }
 
-export const CanSelectSameDay: ComponentStory<typeof Calendar> = () => {
+export const AllowSelectSameDay: ComponentStory<typeof Calendar> = () => {
   const [dates, setDates] = React.useState<CalendarValues>({})
 
   const handleSelectDate = (dates: CalendarValues) => setDates(dates)
 
   return (
-    <Calendar value={dates} onSelectDate={handleSelectDate} canSelectSameDay>
+    <Calendar value={dates} onSelectDate={handleSelectDate} allowSelectSameDay>
       <CalendarControls>
         <CalendarPrevButton />
         <CalendarNextButton />

--- a/src/calendar.stories.tsx
+++ b/src/calendar.stories.tsx
@@ -826,3 +826,26 @@ export const WithCustomDay: ComponentStory<typeof Calendar> = () => {
     </Calendar>
   )
 }
+
+export const CanSelectSameDay: ComponentStory<typeof Calendar> = () => {
+  const [dates, setDates] = React.useState<CalendarValues>({})
+
+  const handleSelectDate = (dates: CalendarValues) => setDates(dates)
+
+  return (
+    <Calendar value={dates} onSelectDate={handleSelectDate} canSelectSameDay>
+      <CalendarControls>
+        <CalendarPrevButton />
+        <CalendarNextButton />
+      </CalendarControls>
+
+      <CalendarMonths>
+        <CalendarMonth>
+          <CalendarMonthName />
+          <CalendarWeek />
+          <CalendarDays />
+        </CalendarMonth>
+      </CalendarMonths>
+    </Calendar>
+  )
+}

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -18,6 +18,7 @@ export type Calendar = React.PropsWithChildren<{
   onSelectDate: (value: CalendarDate | CalendarValues) => void
   months?: number
   locale?: Locale
+  canSelectSameDay?: boolean
   allowOutsideDays?: boolean
   disablePastDates?: boolean | Date
   disableFutureDates?: boolean | Date
@@ -41,6 +42,7 @@ export function Calendar({
   disableWeekends,
   disableDates,
   locale,
+  canSelectSameDay,
   weekdayFormat,
   onSelectDate,
   weekStartsOn,
@@ -82,8 +84,9 @@ export function Calendar({
     }
 
     if (
-      (value.start && isSameDay(date, value.start)) ||
-      (value.end && isSameDay(date, value.end))
+      !canSelectSameDay &&
+      ((value.start && isSameDay(date, value.start)) ||
+        (value.end && isSameDay(date, value.end)))
     ) {
       return
     }

--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -18,7 +18,6 @@ export type Calendar = React.PropsWithChildren<{
   onSelectDate: (value: CalendarDate | CalendarValues) => void
   months?: number
   locale?: Locale
-  canSelectSameDay?: boolean
   allowOutsideDays?: boolean
   disablePastDates?: boolean | Date
   disableFutureDates?: boolean | Date
@@ -29,6 +28,7 @@ export type Calendar = React.PropsWithChildren<{
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
   highlightToday?: boolean
   weekDateSelection?: boolean
+  allowSelectSameDay?: boolean
 }>
 
 export function Calendar({
@@ -42,12 +42,12 @@ export function Calendar({
   disableWeekends,
   disableDates,
   locale,
-  canSelectSameDay,
   weekdayFormat,
   onSelectDate,
   weekStartsOn,
   weekDateSelection,
   highlightToday,
+  allowSelectSameDay,
 }: Calendar) {
   const styles = useMultiStyleConfig('Calendar', {}) as CalendarStyles
 
@@ -84,7 +84,7 @@ export function Calendar({
     }
 
     if (
-      !canSelectSameDay &&
+      !allowSelectSameDay &&
       ((value.start && isSameDay(date, value.start)) ||
         (value.end && isSameDay(date, value.end)))
     ) {


### PR DESCRIPTION
Hello guys (again)!

Recently, I opened a Pull Request (#48 Remove condition that prevent to select same day), but unfortunally i could'nt review and rewrite the code, sorry for the late in that PR.

Well, as suggested by @uselessdev (in the PR quoted above), i choose to follow the approach to add a new property call `allowSelectSameDay`, that will allow the user to select the sameday in a Calendar, in the `start` and `end` dates.

I added too, a new example in the storybook, for the users see this property in action.

All the explanation of why i need this prop, its (again) on #48 PR.

Thanks! :D