### PR TITLE
Pass interval prop to CalendarDay style config

### DIFF
--- a/src/day.tsx
+++ b/src/day.tsx
@@ -6,8 +6,8 @@ import { format } from 'date-fns'
 export type CalendarDay = React.PropsWithChildren<ButtonProps>
 
 export function CalendarDay({ children, ...props }: CalendarDay) {
-  const { day, variant, isDisabled, onSelectDates } = useCalendarDay()
-  const styles = useStyleConfig('CalendarDay', { variant })
+  const { day, interval, variant, isDisabled, onSelectDates } = useCalendarDay()
+  const styles = useStyleConfig('CalendarDay', { variant, interval })
 
   return (
     <Button


### PR DESCRIPTION
This PR passes `interval` into `CalendarDay` style config to allow for more useful styling with start and end date selected buttons.

### Reason
While CSS psuedo-selectors can do many things, it is not possible to theme the selected day styling to handle both cases when only a start date is selected and when a range is selected using pure CSS. 

### Theme Example
Simple theming example using newly passed `interval` prop to apply rounded start/end caps when selecting a range:

```javascript
import { extendTheme } from '@chakra-ui/react';
import { CalendarDefaultTheme } from '@uselessdev/datepicker';

const theme = extendTheme(CalendarDefaultTheme, {
  CalendarDay: {
    variants: {
      selected: ({ interval }) => ({
        // Allow left and right sided border radius for only start date selection
        borderStartRadius: '12px',
        borderEndRadius: '12px',

        // Allow left and right sided border radius on start & end date selection
        ...(Array.isArray(interval) && interval.length > 1 ? {
          borderEndRadius: '0',
          '& ~ &': {
            borderStartRadius: '0',
            borderEndRadius: '12px',
          },
        } : {}),
      },
    },
  },
})
```