### PR TITLE
Weekday letters can contain the same key twice.

### DIFF
--- a/src/month-week.tsx
+++ b/src/month-week.tsx
@@ -25,8 +25,8 @@ export function CalendarWeek() {
 
   return (
     <Grid sx={styles.week}>
-      {week.map(weekday => (
-        <Text key={weekday} sx={styles.weekday}>
+      {week.map((weekday, i) => (
+        <Text key={`${weekday}-${i}`} sx={styles.weekday}>
           {weekday}
         </Text>
       ))}


### PR DESCRIPTION
Fixing:
```Warning: Encountered two children with the same key, `T`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.```