### PR TITLE
Resolve duplicate key issue on next branch

### DIFF
--- a/src/components/week.tsx
+++ b/src/components/week.tsx
@@ -23,8 +23,8 @@ export function CalendarWeek() {
 
   return (
     <Grid sx={styles.week}>
-      {weekdays.map(day => (
-        <Text key={day} sx={styles.weekday}>
+      {weekdays.map((day, i) => (
+        <Text key={`${day}-${i}`} sx={styles.weekday}>
           {day}
         </Text>
       ))}


### PR DESCRIPTION
Fixing same issue on "next" branch for 3.0.0-alpha release:
Warning: Encountered two children with the same key, `T`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.