### PR TITLE
Allow recent framer motion versions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -101,6 +101,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "philzen",
+      "name": "Philzen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1634615",
+      "profile": "https://github.com/Philzen",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "@chakra-ui/react": "^1.8.6 || ^2",
     "date-fns": "^2.25.0",
-    "framer-motion": "^6",
+    "framer-motion": ">=6.5.2",
     "react": "^17.0.2 || ^18",
     "react-dom": "^17.0.2 || ^18"
   }


### PR DESCRIPTION
Closes #79 

--- 

Just bumped into a conflict indicated by `yarn install` after upgrading a project to Chakra V2, including emotion and framer-motion to the latest version – and found #79.

As #81 was closed due to obvious reasons, this should be a clean PR to fix the version conflict.